### PR TITLE
Updated Jellyfin Server version and replaced removed API methods.

### DIFF
--- a/Jellyfin.Plugin.Lastfm/Api/BaseLastfmApiClient.cs
+++ b/Jellyfin.Plugin.Lastfm/Api/BaseLastfmApiClient.cs
@@ -47,10 +47,10 @@
             {
                 Url = BuildPostUrl(request.Secure),
                 CancellationToken = CancellationToken.None,
-                EnableHttpCompression = false,
+                DecompressionMethod = CompressionMethod.None,
             };
 
-            options.SetPostData(EscapeDictionary(data));
+            options.RequestContent = _jsonSerializer.SerializeToString(EscapeDictionary(data));
             using (var response = await _httpClient.Post(options))
             {
                 using (var stream = response.Content)
@@ -85,7 +85,7 @@
             {
                 Url = BuildGetUrl(request.ToDictionary(), request.Secure),
                 CancellationToken = cancellationToken,
-                EnableHttpCompression = false,
+                DecompressionMethod = CompressionMethod.None
             }))
             {
                 try

--- a/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
+++ b/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.2.0.1" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.3.7" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.Lastfm/Providers/LastfmAlbumProvider.cs
+++ b/Jellyfin.Plugin.Lastfm/Providers/LastfmAlbumProvider.cs
@@ -115,7 +115,7 @@ namespace Jellyfin.Plugin.Lastfm.Providers
             {
                 Url = url,
                 CancellationToken = cancellationToken,
-                EnableHttpCompression = false
+                DecompressionMethod = CompressionMethod.None,
 
             }).ConfigureAwait(false))
             {
@@ -140,7 +140,7 @@ namespace Jellyfin.Plugin.Lastfm.Providers
             {
                 Url = url,
                 CancellationToken = cancellationToken,
-                EnableHttpCompression = false
+                DecompressionMethod = CompressionMethod.None
 
             }).ConfigureAwait(false))
             {

--- a/Jellyfin.Plugin.Lastfm/Providers/LastfmArtistProvider.cs
+++ b/Jellyfin.Plugin.Lastfm/Providers/LastfmArtistProvider.cs
@@ -73,7 +73,7 @@ namespace Jellyfin.Plugin.Lastfm.Providers
             {
                 Url = url,
                 CancellationToken = cancellationToken,
-                EnableHttpCompression = false
+                DecompressionMethod = CompressionMethod.None
 
             }).ConfigureAwait(false))
             {


### PR DESCRIPTION
Issue #10 is fixed with this PR. The CompressionMethod was changed to an Enum, and setPostData was replaced with updating RequestContent directly.