### PR TITLE
Fix Jellyfin crashing when Item.Artists in PlaybackStart/PlaybackStopped is empty

### DIFF
--- a/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
@@ -164,9 +164,9 @@
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(item.Artists.First()) || string.IsNullOrWhiteSpace(item.Name))
+            if (string.IsNullOrWhiteSpace(item.Artists.FirstOrDefault()) || string.IsNullOrWhiteSpace(item.Name))
             {
-                _logger.LogInformation("track {0} is missing  artist ({1}) or track name ({2}) metadata. Not submitting", item.Path, item.Artists.First(), item.Name);
+                _logger.LogInformation("track {0} is missing  artist ({1}) or track name ({2}) metadata. Not submitting", item.Path, item.Artists.FirstOrDefault(), item.Name);
                 return;
             }
             await _apiClient.Scrobble(item, lastfmUser).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
@@ -208,9 +208,9 @@
             }
 
             var item = e.Item as Audio;
-            if (string.IsNullOrWhiteSpace(item.Artists.First()) || string.IsNullOrWhiteSpace(item.Name))
+            if (string.IsNullOrWhiteSpace(item.Artists.FirstOrDefault()) || string.IsNullOrWhiteSpace(item.Name))
             {
-                _logger.LogInformation("track {0} is missing  artist ({1}) or track name ({2}) metadata. Not submitting", item.Path, item.Artists.First(), item.Name);
+                _logger.LogInformation("track {0} is missing artist ({1}) or track name ({2}) metadata. Not submitting", item.Path, item.Artists.FirstOrDefault(), item.Name);
                 return;
             }
             await _apiClient.NowPlaying(item, lastfmUser).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #35. This crash is caused by a song's Artists field being empty when Jellyfin is missing metadata for it. The call to `First()` throws an exception when the list is empty, instead of simply defaulting to `null`. With this fix, it will simply log a message like:

```
[21:04:28] [INF] [32] Jellyfin.Plugin.Lastfm.ServerEntryPoint: track D:\Music\PAYDAY 2 - Soundtrack\payday_2_soundtrack_remix_material\fuse_box_132_bpm\fuse_box_synth_4.wav is missing artist (null) or track name (fuse_box_synth_4) metadata. Not submitting
```