### PR TITLE
Fix LastFM Loved Tracks Sync

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -1,0 +1,18 @@
+name: 'Build Plugin'
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@master

--- a/Jellyfin.Plugin.Lastfm/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lastfm/Configuration/configPage.html
@@ -1,10 +1,13 @@
 ﻿<!DOCTYPE html>
 <html>
+
 <head>
     <title>Last.fm Scrobbler Configuration</title>
 </head>
+
 <body>
-    <div id="LastfmScrobblerConfigurationPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
+    <div id="LastfmScrobblerConfigurationPage" data-role="page" class="page type-interior pluginConfigurationPage"
+        data-require="emby-input,emby-button,emby-select,emby-checkbox">
 
         <div data-role="content">
             <div class="content-primary">
@@ -114,13 +117,13 @@
                     this.$el.find('#optionScrobble').prop('checked', data.Options.Scrobble);
                     this.$el.find('#optionFavourite').prop('checked', data.Options.SyncFavourites);
 
-                    //Dont forget to call checkboxradio('refresh') otherwise the UI wont update
+                    // Don't forget to call checkboxradio('refresh') otherwise the UI wont update
                 },
 
                 save: function (username, password) {
                     var userConfig = this.getCurrentSelectedUser();
 
-                    //If the conig for the user doesnt exist, create one
+                    //If the config for the user doesn't exist, create one
                     if (!userConfig) {
                         userConfig = $.extend({}, this.configDefaults, { MediaBrowserUserId: this.getCurrentSelectedUserId() });
 
@@ -143,10 +146,10 @@
                     //Get session with user data
                     ApiClient.LastfmGetMobileSession(username, password).then($.proxy(function (data) {
                         //Check if we have data
-                        if (data && data.Session) {
+                        if (data && data.session) {
 
-                            userConfig.Username = data.Session.Name;
-                            userConfig.SessionKey = data.Session.Key;
+                            userConfig.Username = data.session.name;
+                            userConfig.SessionKey = data.session.key;
 
                             //Save
                             this.doSave();
@@ -154,8 +157,8 @@
                             return;
                         }
 
-                        Dashboard.alert(data.Message || "Something went wrong");
-                        console.log(data.Message);
+                        Dashboard.alert(data.message || "Something went wrong");
+                        console.log(data.message);
                     }, this));
                     Dashboard.hideLoadingMsg();
                 },
@@ -253,4 +256,5 @@
             };</script>
     </div>
 </body>
+
 </html>

--- a/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
+++ b/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
@@ -2,15 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <AssemblyVersion>8.0.0.2</AssemblyVersion>
-    <FileVersion>8.0.0.2</FileVersion>
+    <AssemblyVersion>8.0.0.3</AssemblyVersion>
+    <FileVersion>8.0.0.3</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <None Remove="Configuration\configPage.html" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Configuration\configPage.html" />
   </ItemGroup>
 
@@ -18,7 +15,6 @@
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.Lastfm/Models/MobileSession.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/MobileSession.cs
@@ -1,17 +1,16 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models
 {
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class MobileSession
     {
-        [DataMember(Name = "name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [DataMember(Name = "key")]
+        [JsonPropertyName("key")]
         public string Key { get; set; }
 
-        [DataMember(Name = "subscriber")]
+        [JsonPropertyName("subscriber")]
         public int Subscriber { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Lastfm/Models/Responses/BaseResponse.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Responses/BaseResponse.cs
@@ -1,14 +1,13 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models.Responses
 {
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class BaseResponse
     {
-        [DataMember(Name="message")]
+        [JsonPropertyName("message")]
         public string Message { get; set; }
 
-        [DataMember(Name="error")]
+        [JsonPropertyName("error")]
         public int ErrorCode { get; set; }
 
         public bool IsError()

--- a/Jellyfin.Plugin.Lastfm/Models/Responses/GetTracksResponse.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Responses/GetTracksResponse.cs
@@ -1,12 +1,11 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models.Responses
 {
     using System.Collections.Generic;
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class GetTracksResponse : BaseResponse
     {
-        [DataMember(Name="tracks")]
+        [JsonPropertyName("tracks")]
         public GetTracksTracks Tracks { get; set; }
 
         public bool HasTracks()
@@ -15,26 +14,24 @@
         }
     }
 
-    [DataContract]
     public class GetTracksTracks
     {
-        [DataMember(Name="track")]
+        [JsonPropertyName("track")]
         public List<LastfmTrack> Tracks { get; set; }
 
-        [DataMember(Name = "@attr")]
+        [JsonPropertyName("@attr")]
         public GetTracksMeta Metadata { get; set; }
     }
 
-    [DataContract]
     public class GetTracksMeta
     {
-        [DataMember(Name = "totalPages")]
+        [JsonPropertyName("totalPages")]
         public int TotalPages { get; set; }
 
-        [DataMember(Name = "total")]
+        [JsonPropertyName("total")]
         public int TotalTracks { get; set; }
 
-        [DataMember(Name = "page")]
+        [JsonPropertyName("page")]
         public int Page { get; set; }
 
         public bool IsLastPage()

--- a/Jellyfin.Plugin.Lastfm/Models/Responses/LovedTracksResponse.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Responses/LovedTracksResponse.cs
@@ -1,12 +1,11 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models.Responses
 {
     using System.Collections.Generic;
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class LovedTracksResponse : BaseResponse
     {
-        [DataMember(Name = "lovedtracks")]
+        [JsonPropertyName("lovedtracks")]
         public LovedTracks LovedTracks { get; set; }
 
         public bool HasLovedTracks()
@@ -15,28 +14,26 @@
         }
     }
 
-    [DataContract]
     public class LovedTracks
     {
-        [DataMember(Name = "track")]
+        [JsonPropertyName("track")]
         public List<LastfmLovedTrack> Tracks { get; set; }
 
 
-        [DataMember(Name = "@attr")]
+        [JsonPropertyName("@attr")]
         public LovedTracksMeta Metadata { get; set; }
     }
 
 
-    [DataContract]
     public class LovedTracksMeta
     {
-        [DataMember(Name = "totalPages")]
+        [JsonPropertyName("totalPages")]
         public int TotalPages { get; set; }
 
-        [DataMember(Name = "total")]
+        [JsonPropertyName("total")]
         public int TotalTracks { get; set; }
 
-        [DataMember(Name = "page")]
+        [JsonPropertyName("page")]
         public int Page { get; set; }
 
         public bool IsLastPage()

--- a/Jellyfin.Plugin.Lastfm/Models/Responses/MobileSessionResponse.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Responses/MobileSessionResponse.cs
@@ -1,11 +1,10 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models.Responses
 {
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class MobileSessionResponse : BaseResponse
     {
-        [DataMember(Name="session")]
+        [JsonPropertyName("session")]
         public MobileSession Session { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Lastfm/Models/Responses/ScrobbleResponse.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Responses/ScrobbleResponse.cs
@@ -1,11 +1,10 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models.Responses
 {
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class ScrobbleResponse : BaseResponse
     {
-        [DataMember(Name = "scrobbles")]
+        [JsonPropertyName("scrobbles")]
         public Scrobbles Scrobbles { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Lastfm/Models/Scrobble.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Scrobble.cs
@@ -1,22 +1,19 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models
 {
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    //Wow what a bad response object!
-    [DataContract]
     public class Scrobbles
     {
-        [DataMember(Name = "@attr")]
+        [JsonPropertyName("@attr")]
         public ScrobbleAttributes Attributes { get; set; }
     }
 
-    [DataContract]
     public class ScrobbleAttributes
     {
-        [DataMember(Name = "accepted")]
+        [JsonPropertyName("accepted")]
         public bool Accepted { get; set; }
 
-        [DataMember(Name = "ignored")]
+        [JsonPropertyName("ignored")]
         public bool Ignored { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Lastfm/Models/Tracks.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Tracks.cs
@@ -1,27 +1,25 @@
 ﻿namespace Jellyfin.Plugin.Lastfm.Models
 {
-    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
 
-    [DataContract]
     public class BaseLastfmTrack
     {
-        [DataMember(Name="artist")]
+        [JsonPropertyName("artist")]
         public LastfmArtist Artist { get; set; }
 
-        [DataMember(Name = "name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [DataMember(Name = "mbid")]
+        [JsonPropertyName("mbid")]
         public string MusicBrainzId { get; set; }
     }
 
-    [DataContract]
     public class LastfmArtist
     {
-        [DataMember(Name="name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [DataMember(Name = "mbid")]
+        [JsonPropertyName("mbid")]
         public string MusicBrainzId { get; set; }
     }
 
@@ -29,10 +27,10 @@
     {
     }
 
-    [DataContract]
+
     public class LastfmTrack : BaseLastfmTrack
     {
-        [DataMember(Name="playcount")]
+        [JsonPropertyName("playcount")]
         public int PlayCount { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Lastfm/Utils/Helpers.cs
+++ b/Jellyfin.Plugin.Lastfm/Utils/Helpers.cs
@@ -84,9 +84,5 @@
             return null;
         }
 
-        public static LastfmLovedTrack FindMatchedLastfmSong(List<LastfmLovedTrack> tracks, Audio song)
-        {
-            return tracks.FirstOrDefault(lastfmTrack => StringHelper.IsLike(song.Name, lastfmTrack.Name));
-        }
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "LastFM"
 guid: "5e7fe7f0-b048-429e-a431-b1a7e69c930d"
-version: "8.0.0.2"
+version: "8.0.0.3"
 targetAbi: "10.8.0.0"
 framework: "net6.0"
 overview: "A plugin that scrobbles your Jellyfin music to LastFM."
@@ -12,4 +12,4 @@ owner: "jesseward"
 artifacts:
   - "Jellyfin.Plugin.Lastfm.dll"
 changelog: >
-  Fix for 10.8 compatability.
+  Fix LastFM Loved Tracks Synching.

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,15 @@
+---
+name: "LastFM"
+guid: "5e7fe7f0-b048-429e-a431-b1a7e69c930d"
+version: "8.0.0.2"
+targetAbi: "10.8.0.0"
+framework: "net6.0"
+overview: "A plugin that scrobbles your Jellyfin music to LastFM."
+description: >
+  Scrobble LastFM plays with Jellyfin.
+category: "Music"
+owner: "jesseward"
+artifacts:
+  - "Jellyfin.Plugin.Lastfm.dll"
+changelog: >
+  Fix for 10.8 compatability.


### PR DESCRIPTION
## Related

* Related to https://github.com/jesseward/jellyfin-plugin-lastfm/issues/44
* Related to https://github.com/jesseward/jellyfin-plugin-lastfm/issues/40

## Summary

Moved from `System.Runtime.Serialization` to `System.Text.json.Serialization` json handling in API model responses.

This allows the scheduled task to fetch the my set of Last.FM loved tracks and matches against my JF library. 

Also changed the way that the lovedtracks from LastFM are matched to the JellyFin library. There is an explicit check against the MusicbrainzID now. The existing logic that used the linq query was too greedy when matching songs.

```sh
[2023-06-04 16:53:08.713 -07:00] [INF] [23] Jellyfin.Plugin.Lastfm.ScheduledTasks.ImportLastfmData: Retrieved 214 lovedTracks from LastFM for user "..."
[2023-06-04 16:56:10.315 -07:00] [INF] [23] Jellyfin.Plugin.Lastfm.ScheduledTasks.ImportLastfmData: Finished Last.fm lovedTracks sync for "...". Matched Songs: 268
[2023-06-04 16:56:10.315 -07:00] [INF] [23] Emby.Server.Implementations.ScheduledTasks.TaskManager: "Import Last.fm Loved Tracks" Completed after 3 minute(s) and 2 seconds
[2023-06-04 16:56:10.316 -07:00] [INF] [23] Emby.Server.Implementations.ScheduledTasks.TaskManager: ExecuteQueuedTasks
```