### PR TITLE
Add a plugin build CI workflow.

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -1,0 +1,18 @@
+name: 'Build Plugin'
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/build.yaml@master

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,15 @@
+---
+name: "LastFM"
+guid: "5e7fe7f0-b048-429e-a431-b1a7e69c930d"
+version: "8.0.0.2"
+targetAbi: "10.8.0.0"
+framework: "net6.0"
+overview: "A plugin that scrobbles your Jellyfin music to LastFM."
+description: >
+  Scrobble LastFM plays with Jellyfin.
+category: "Music"
+owner: "jesseward"
+artifacts:
+  - "Jellyfin.Plugin.Lastfm.dll"
+changelog: >
+  Fix for 10.8 compatability.


### PR DESCRIPTION
This will also eventually support the use of jellyfin-plugin-repository-manager