### PR TITLE
Initial pass at support for 10.9.1

### DIFF
--- a/.devcontainer/Makefile
+++ b/.devcontainer/Makefile
@@ -2,13 +2,13 @@ all : clean restore down build up
 
 clean:
 	cd /workspaces/jellyfin-plugin-lastfm && dotnet clean
-	rm -rf /opt/jellyfin/config/plugins/LastFM
+	rm -rf /opt/jellyfin/data/plugins/LastFM
 
 restore:
 	cd /workspaces/jellyfin-plugin-lastfm && dotnet restore
 
 build:
-	cd /workspaces/jellyfin-plugin-lastfm && dotnet build --output /opt/jellyfin/config/plugins/LastFM
+	cd /workspaces/jellyfin-plugin-lastfm && dotnet build --output /opt/jellyfin/data/plugins/LastFM
 
 up:
 	/usr/local/share/jellyfin-init.sh &

--- a/.devcontainer/Makefile
+++ b/.devcontainer/Makefile
@@ -8,7 +8,8 @@ restore:
 	cd /workspaces/jellyfin-plugin-lastfm && dotnet restore
 
 build:
-	cd /workspaces/jellyfin-plugin-lastfm && dotnet build --output /opt/jellyfin/data/plugins/LastFM
+	mkdir /opt/jellyfin/data/plugins/LastFM
+	cd /workspaces/jellyfin-plugin-lastfm && dotnet build --property:OutputPath=/opt/jellyfin/data/plugins/LastFM
 
 up:
 	/usr/local/share/jellyfin-init.sh &

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 			"version": "latest"
 		},
 		"ghcr.io/devcontainers/features/sshd:1": {},
-		"ghcr.io/jesseward/devcontainer-features/jellyfin:1.0.1": {}
+		"ghcr.io/jesseward/devcontainer-features/jellyfin:1.1.0": {}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
 	"name": "jellyfin-plugin-lastfm",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:0-7.0",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
 	"features": {
-		"ghcr.io/devcontainers/features/dotnet:2.0.3": {
+		"ghcr.io/devcontainers/features/dotnet:2.0.5": {
 			"installUsingApt": true,
 			"version": "latest"
 		},

--- a/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
+++ b/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AssemblyVersion>8.0.0.4</AssemblyVersion>
-    <FileVersion>8.0.0.4</FileVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyVersion>8.1.0.0</AssemblyVersion>
+    <FileVersion>8.1.0.0</FileVersion>
+    <Version>8.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.Lastfm/Models/Scrobble.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Scrobble.cs
@@ -10,10 +10,14 @@
 
     public class ScrobbleAttributes
     {
+        // https://www.last.fm/api/show/track.scrobble
+        // accepted : Number of accepted scrobbles
         [JsonPropertyName("accepted")]
-        public bool Accepted { get; set; }
+        public int Accepted { get; set; }
 
+        // https://www.last.fm/api/show/track.scrobble
+        // ignored : Number of ignored scrobbles (see ignoredMessage for details)
         [JsonPropertyName("ignored")]
-        public bool Ignored { get; set; }
+        public int Ignored { get; set; }
     }
 }

--- a/Jellyfin.Plugin.Lastfm/PluginServiceRegistor.cs
+++ b/Jellyfin.Plugin.Lastfm/PluginServiceRegistor.cs
@@ -1,0 +1,18 @@
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.Lastfm
+{
+    /// <summary>
+    /// Register LastFM Scrobbler services
+    /// </summary>
+    public class PluginServiceRegistrator : IPluginServiceRegistrator
+    {
+        /// <inheritdoc />
+        public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+        {
+            serviceCollection.AddHostedService<ServerEntryPoint>();
+        }
+    }
+}

--- a/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
@@ -16,7 +16,7 @@
     /// <summary>
     /// Class ServerEntryPoint
     /// </summary>
-    public class ServerEntryPoint : IHostedService
+    public class ServerEntryPoint : IHostedService, IDisposable
     {
 
         // if the length of the song is >= 30 seconds, allow scrobble.
@@ -53,24 +53,12 @@
         }
 
         /// <summary>
-        /// Runs this instance.
-        /// </summary>
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            //Bind events
-            _sessionManager.PlaybackStart += PlaybackStart;
-            _sessionManager.PlaybackStopped += PlaybackStopped;
-            _userDataManager.UserDataSaved += UserDataSaved;
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
         /// Let last fm know when a user favourites or unfavourites a track
         /// </summary>
         async void UserDataSaved(object sender, UserDataSaveEventArgs e)
         {
             // We only care about audio
-            if (!(e.Item is Audio))
+            if (e.Item is not Audio)
                 return;
 
             // We also only care about User rating changes
@@ -107,7 +95,7 @@
         private async void PlaybackStopped(object sender, PlaybackStopEventArgs e)
         {
             // We only care about audio
-            if (!(e.Item is Audio))
+            if (e.Item is not Audio)
                 return;
 
             var item = e.Item as Audio;
@@ -177,7 +165,7 @@
         private async void PlaybackStart(object sender, PlaybackProgressEventArgs e)
         {
             // We only care about audio
-            if (!(e.Item is Audio))
+            if (e.Item is not Audio)
                 return;
 
             var user = e.Users.FirstOrDefault();
@@ -216,6 +204,18 @@
         }
 
         /// <summary>
+        /// Runs this instance.
+        /// </summary>
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            //Bind events
+            _sessionManager.PlaybackStart += PlaybackStart;
+            _sessionManager.PlaybackStopped += PlaybackStopped;
+            _userDataManager.UserDataSaved += UserDataSaved;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public Task StopAsync(CancellationToken cancellationToken)
@@ -228,6 +228,11 @@
             // Clean up
             _apiClient = null;
             return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,9 @@
 ---
 name: "LastFM"
 guid: "5e7fe7f0-b048-429e-a431-b1a7e69c930d"
-version: "8.0.0.4"
-targetAbi: "10.8.0.0"
-framework: "net6.0"
+version: "8.1.0.0"
+targetAbi: "10.9.0.0"
+framework: "net8.0"
 overview: "A plugin that scrobbles your Jellyfin music to LastFM."
 description: >
   Scrobble LastFM plays with Jellyfin.
@@ -12,4 +12,4 @@ owner: "jesseward"
 artifacts:
   - "Jellyfin.Plugin.Lastfm.dll"
 changelog: >
-  Fix LastFM Loved Tracks Synching.
+  Enable support for JellyFin 10.9.0


### PR DESCRIPTION
## Summary

This introduces compatibility with 10.9.x Jellyfin versions

* Support for JF 10.9.1 (https://github.com/jesseward/jellyfin-plugin-lastfm/issues/63)
* Tag plugin version 8.1.0.0
* Bump to dot net 8.0
* Swap the ServerEntryPoint interface from `IServerEntryPoint` to `IHostedService`
* ingest `mcr.microsoft.com/devcontainers/dotnet:8.0"` as the devcontainer
* Fix for scrobble model (bool becomes int) - https://github.com/jesseward/jellyfin-plugin-lastfm/issues/59