### PR TITLE
Add album artist information to scrobbles and now-playing requests

### DIFF
--- a/Jellyfin.Plugin.Lastfm/Api/LastfmApiClient.cs
+++ b/Jellyfin.Plugin.Lastfm/Api/LastfmApiClient.cs
@@ -67,6 +67,11 @@
             {
                 request.MbId = item.ProviderIds["MusicBrainzTrack"];
             }
+            var albumArtist = item.AlbumArtists.First();
+            if (!string.IsNullOrWhiteSpace(albumArtist) && albumArtist != request.Artist)
+            {
+                request.AlbumArtist = albumArtist;
+            }
 
             try
             {
@@ -82,7 +87,7 @@
             }
             catch (Exception ex)
             {
-                _logger.LogError("Failed to Scrobble track: track: ex={0}, name={1}, track={2}, artist={3}, album={4}, mbid={5}", ex, item.Name, request.Track, request.Artist, request.Album, request.MbId);
+                _logger.LogError("Failed to Scrobble track: track: ex={0}, name={1}, track={2}, artist={3}, album={4}, albumArtist={5}, mbid={6}", ex, item.Name, request.Track, request.Artist, request.Album, request.AlbumArtist, request.MbId);
             }
         }
 
@@ -108,6 +113,11 @@
             {
                 request.MbId = item.ProviderIds["MusicBrainzTrack"];
             }
+            var albumArtist = item.AlbumArtists.First();
+            if (!string.IsNullOrWhiteSpace(albumArtist) && albumArtist != request.Artist)
+            {
+                request.AlbumArtist = albumArtist;
+            }
 
             // Add duration
             if (item.RunTimeTicks != null)
@@ -126,7 +136,7 @@
             }
             catch (Exception ex)
             {
-                _logger.LogError("Failed to send now playing for track: ex={0}, name={1}, track={2}, artist={3}, album={4}, mbid={5}", ex, item.Name, request.Track, request.Artist, request.Album, request.MbId);
+                _logger.LogError("Failed to send now playing for track: ex={0}, name={1}, track={2}, artist={3}, album={4}, albumArtist={5}, mbid={6}", ex, item.Name, request.Track, request.Artist, request.Album, request.AlbumArtist, request.MbId);
             }
         }
 

--- a/Jellyfin.Plugin.Lastfm/Models/Requests/NowPlayingRequest.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Requests/NowPlayingRequest.cs
@@ -9,6 +9,7 @@
         public string Track { get; set; }
         public string Album { get; set; }
         public string Artist { get; set; }
+        public string AlbumArtist { get; set; }
         public int Duration { get; set; }
         public string MbId { get; set; }
 
@@ -28,6 +29,10 @@
             if (!string.IsNullOrWhiteSpace(MbId))
             {
                 nowPlaying.Add("mbid", MbId);
+            }
+            if (!string.IsNullOrWhiteSpace(AlbumArtist))
+            {
+                nowPlaying.Add("albumArtist", AlbumArtist);
             }
 
             return nowPlaying;

--- a/Jellyfin.Plugin.Lastfm/Models/Requests/ScrobbleRequest.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Requests/ScrobbleRequest.cs
@@ -8,11 +8,12 @@
     {
         // API docs for scrobbling located at https://www.last.fm/api/show/track.scrobble
         // Track, Artist, and Timestamp are required
-        // Album and MusicBrainzid are optional.
+        // Album, ArtistAlbum, and MusicBrainzid are optional.
         public string Track { get; set; }
         public string Artist { get; set; }
         public int Timestamp { get; set; }
         public string Album { get; set; }
+        public string AlbumArtist { get; set; }
         public string MbId { get; set; }
 
         public override Dictionary<string, string> ToDictionary()
@@ -30,6 +31,10 @@
             if (!string.IsNullOrWhiteSpace(MbId))
             {
                 scrobbleRequest.Add("mbid", MbId);
+            }
+            if (!string.IsNullOrWhiteSpace(AlbumArtist))
+            {
+                scrobbleRequest.Add("albumArtist", AlbumArtist);
             }
 
             return scrobbleRequest;


### PR DESCRIPTION
These are optional but can be added so that last.fm correctly assigns scrobbles to the right album.

Fixes #33