### PR TITLE
Use start time when scrobbling

### DIFF
--- a/Jellyfin.Plugin.Lastfm/Api/LastfmApiClient.cs
+++ b/Jellyfin.Plugin.Lastfm/Api/LastfmApiClient.cs
@@ -44,14 +44,14 @@
             return response;
         }
 
-        public async Task Scrobble(Audio item, LastfmUser user)
+        public async Task Scrobble(Audio item, LastfmUser user, long timestamp)
         {
             // API docs -> https://www.last.fm/api/show/track.scrobble
             var request = new ScrobbleRequest
             {
                 Track = item.Name,
                 Artist = item.Artists.First(),
-                Timestamp = Helpers.CurrentTimestamp(),
+                Timestamp = timestamp,
 
                 ApiKey = Strings.Keys.LastfmApiKey,
                 Method = Strings.Methods.Scrobble,

--- a/Jellyfin.Plugin.Lastfm/Models/Requests/ScrobbleRequest.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/Requests/ScrobbleRequest.cs
@@ -11,7 +11,7 @@
         // Album, ArtistAlbum, and MusicBrainzid are optional.
         public string Track { get; set; }
         public string Artist { get; set; }
-        public int Timestamp { get; set; }
+        public long Timestamp { get; set; }
         public string Album { get; set; }
         public string AlbumArtist { get; set; }
         public string MbId { get; set; }

--- a/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
@@ -12,6 +12,7 @@
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Hosting;
     using System.Threading;
+    using Jellyfin.Plugin.Lastfm.Utils;
 
     /// <summary>
     /// Class ServerEntryPoint
@@ -31,6 +32,7 @@
 
         private LastfmApiClient _apiClient;
         private readonly ILogger<ServerEntryPoint> _logger;
+        private long _playbackTimestamp;
 
         /// <summary>
         /// Gets the instance.
@@ -156,7 +158,8 @@
                 _logger.LogInformation("track {0} is missing  artist ({1}) or track name ({2}) metadata. Not submitting", item.Path, item.Artists.FirstOrDefault(), item.Name);
                 return;
             }
-            await _apiClient.Scrobble(item, lastfmUser).ConfigureAwait(false);
+
+            await _apiClient.Scrobble(item, lastfmUser, _playbackTimestamp).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -200,6 +203,9 @@
                 _logger.LogInformation("track {0} is missing artist ({1}) or track name ({2}) metadata. Not submitting", item.Path, item.Artists.FirstOrDefault(), item.Name);
                 return;
             }
+
+            _playbackTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
             await _apiClient.NowPlaying(item, lastfmUser).ConfigureAwait(false);
         }
 

--- a/Jellyfin.Plugin.Lastfm/Utils/Helpers.cs
+++ b/Jellyfin.Plugin.Lastfm/Utils/Helpers.cs
@@ -33,23 +33,6 @@
             data.Add("api_sig", CreateSignature(data));
         }
 
-        public static int ToTimestamp(DateTime date)
-        {
-            return Convert.ToInt32((date - new DateTime(1970, 1, 1)).TotalSeconds);
-        }
-
-        public static DateTime FromTimestamp(double timestamp)
-        {
-            var date = new DateTime(1970, 1, 1, 0, 0, 0, 0);
-
-            return date.AddSeconds(timestamp).ToLocalTime();
-        }
-
-        public static int CurrentTimestamp()
-        {
-            return ToTimestamp(DateTime.UtcNow);
-        }
-
         public static string DictionaryToQueryString(Dictionary<string, string> data)
         {
             return String.Join("&", data.Where(k => !String.IsNullOrWhiteSpace(k.Value)).Select(kvp => String.Format("{0}={1}", Uri.EscapeDataString(kvp.Key), Uri.EscapeDataString(kvp.Value))));


### PR DESCRIPTION
When scrobbling, use the time the track started rather than when it finished.
This PR also removes the (now) unused helper methods for getting the timestamp.
Fixes #54 