### PR TITLE
Fix #67

### DIFF
--- a/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
@@ -84,6 +84,12 @@
             if (Plugin.Syncing)
                 return;
 
+            if (!lastfmUser.Options.SyncFavourites)
+            {
+                _logger.LogDebug("{0} ({1}) does not want to sync liked songs", user.Username, lastfmUser.Username);
+                return;
+            }
+
             await _apiClient.LoveTrack(item, lastfmUser, e.UserData.IsFavorite).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
This pr fixes #67 which causes the favourited songs to sync even when the user has configured them not to.