### PR TITLE
Remove use of non-existent variable

### DIFF
--- a/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
+++ b/Jellyfin.Plugin.Lastfm/ServerEntryPoint.cs
@@ -86,7 +86,7 @@
 
             if (!lastfmUser.Options.SyncFavourites)
             {
-                _logger.LogDebug("{0} ({1}) does not want to sync liked songs", user.Username, lastfmUser.Username);
+                _logger.LogDebug("{0} does not want to sync liked songs", lastfmUser.Username);
                 return;
             }
 


### PR DESCRIPTION
Not sure which `user` was intended. In any case, this code doesn't compile.