### PR TITLE
Add Alternative Mode for scrobbling on UserDataSaved events

### DIFF
--- a/Jellyfin.Plugin.Lastfm/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lastfm/Configuration/configPage.html
@@ -33,6 +33,12 @@
                             <span>Sync favourites for this user?</span>
                         </label>
                     </div>
+                    <div class="checkboxContainer">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="optionAltMode" name="optionAltMode" />
+                            <span>Use alternative mode and scrobble on UserDataSaved events instead of PlaybackStopped?</span>
+                        </label>
+                    </div>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                             <span>Save</span>
@@ -56,7 +62,8 @@
                     MediaBrowserUserId: '',
                     Options: {
                         Scrobble: false,
-                        SyncFavourites: false
+                        SyncFavourites: false,
+                        AlternativeMode: false
                     }
                 },
 
@@ -116,6 +123,7 @@
                     this.$el.find('#password').val(data.SessionKey);
                     this.$el.find('#optionScrobble').prop('checked', data.Options.Scrobble);
                     this.$el.find('#optionFavourite').prop('checked', data.Options.SyncFavourites);
+                    this.$el.find('#optionAltMode').prop('checked', data.Options.AlternativeMode);
 
                     // Don't forget to call checkboxradio('refresh') otherwise the UI wont update
                 },
@@ -204,6 +212,7 @@
 
                     options.Scrobble = this.$el.find('#optionScrobble').prop('checked');
                     options.SyncFavourites = this.$el.find('#optionFavourite').prop('checked');
+                    options.AlternativeMode = this.$el.find('#optionAltMode').prop('checked');
                     return options;
                 },
 

--- a/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
+++ b/Jellyfin.Plugin.Lastfm/Jellyfin.Plugin.Lastfm.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.10.*-*" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.Lastfm/Models/LastfmUser.cs
+++ b/Jellyfin.Plugin.Lastfm/Models/LastfmUser.cs
@@ -16,7 +16,8 @@
 
     public class LastFmUserOptions
     {
-        public bool Scrobble       { get; set; }
-        public bool SyncFavourites { get; set; }
+        public bool Scrobble        { get; set; }
+        public bool SyncFavourites  { get; set; }
+        public bool AlternativeMode { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This error is returned from the last.fm API. If you're certain you have correctl
 
 This appears to be due to the method in which these clients play media files. This plugin relies the invocation of the `PlaybackStartEvent` and `PlaybackStopEvent` events. Some details and references to upstream issues is located at https://github.com/jesseward/jellyfin-plugin-lastfm/issues/27#issuecomment-744031810
 
+As an workaround, you can enable "Alternative Mode" in settings, which will scrobble on `UserDataSaved` events instead. See the [documentation of `jellyfin-plugin-listenbrainz`](https://github.com/lyarenei/jellyfin-plugin-listenbrainz/blob/main/doc/configuration.md#use-alternative-event-for-recognizing-listens) for the differences of the events.
+
 ### (very) Poor matching of artist/album/track names in the `LovedTracks` flow.
 
 Syncing of Loved tracks between LastFM and this plugin is subpar. This is due to the `IsLike` method that is used to compare track metadata. See https://github.com/jesseward/jellyfin-plugin-lastfm/issues/24


### PR DESCRIPTION
This is inspired by the [Alternative Mode in `jellyfin-plugin-listenbrainz`](https://github.com/lyarenei/jellyfin-plugin-listenbrainz/blob/main/doc/configuration.md#use-alternative-event-for-recognizing-listens) which allows to use `UserDataSaved` events instead of `PlaybackStopped` ones, to help clients that do not (or badly) suport `PlaybackStopped` -- like Symfonium.